### PR TITLE
configure middleclick to toggle dnd state

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -288,6 +288,17 @@ function enable() {
     snLabel.set_text(snoozeText);
   }
 
+  // configure middle click to toggle the dnd state
+  dndButton.actor.connect('button-press-event',  function(actor, event) {
+    let button = event.get_button();
+    if (button == 2) {
+      if (dndMenu.isOpen) {
+        dndMenu.close();
+      }
+      setDNDState(!dndOn);
+    };
+  });
+
   dndMenu.connect("open-state-changed", function(menu, isOpen) {
     if (isOpen) {
       updateSNLabel();


### PR DESCRIPTION
@muravjov ... great extensions! This PR added middle click functionality to toggel the DND state, similar to appindicators. Hope you will merge it.